### PR TITLE
Score submission endpoints

### DIFF
--- a/src/api/Server.js
+++ b/src/api/Server.js
@@ -35,8 +35,10 @@ module.exports = class Server {
 
     this.express.get('/scores/:mods', this.routes.getModScores)
     this.express.get('/scores/:mods/:id', this.routes.getScore)
-    // this.express.put('/scores/:mods/:id', this.routes.putScore)
     this.express.delete('/scores/:mods/:id', this.routes.deleteScore)
+
+    this.express.get('/submitted', this.routes.getSubmittedScores)
+    this.express.put('/submitted/:id', this.routes.putSubmittedScore)
   }
 
   start () {

--- a/src/api/ServerRoutes.js
+++ b/src/api/ServerRoutes.js
@@ -16,8 +16,10 @@ module.exports = class ServerRoutes {
 
     this.getModScores = this.getModScores.bind(this)
     this.getScore = this.getScore.bind(this)
-    // this.putScore = this.putScore.bind(this)
     this.deleteScore = this.deleteScore.bind(this)
+
+    this.getSubmittedScores = this.getSubmittedScores.bind(this)
+    this.putSubmittedScore = this.putSubmittedScore.bind(this)
   }
 
   // --- ECHO ---
@@ -88,16 +90,25 @@ module.exports = class ServerRoutes {
       .catch((err) => res.status(400).json({ error: err.message }))
   }
 
-  putScore (req, res) {
-    console.info(`Server::getScore() - params: ${JSON.stringify(req.params)}`)
-    this.#facade.putScore(req.params.mods, req.params.id)
+  deleteScore (req, res) {
+    console.info(`Server::deleteScore() - params: ${JSON.stringify(req.params)}`)
+    this.#facade.deleteScore(req.params.mods, req.params.id)
       .then((response) => res.status(200).json({ result: response }))
       .catch((err) => res.status(400).json({ error: err.message }))
   }
 
-  deleteScore (req, res) {
-    console.info(`Server::deleteScore() - params: ${JSON.stringify(req.params)}`)
-    this.#facade.deleteScore(req.params.mods, req.params.id)
+  // --- SUBMITTED SCORES ---
+
+  getSubmittedScores (req, res) {
+    console.info('Server::getSubmittedScores()')
+    this.#facade.getSubmittedScores()
+      .then((response) => res.status(200).json({ result: response }))
+      .catch((err) => res.status(400).json({ error: err.message }))
+  }
+
+  putSubmittedScore (req, res) {
+    console.info(`Server::putSubmittedScore() - params: ${JSON.stringify(req.params)}`)
+    this.#facade.putSubmittedScore(req.params.id)
       .then((response) => res.status(200).json({ result: response }))
       .catch((err) => res.status(400).json({ error: err.message }))
   }

--- a/src/controller/OsuWrapper.js
+++ b/src/controller/OsuWrapper.js
@@ -146,4 +146,21 @@ module.exports = class OsuWrapper {
     const data = await response.json()
     return data
   }
+
+  // Doesn't check if score IDs exist
+  async fetchScores (scoreIds) {
+    console.info(`OsuWrapper::fetchScores( ${scoreIds} )`)
+    if (!Array.isArray(scoreIds)) {
+      throw new Error('scoreIds must be an array')
+    }
+
+    const ret = []
+    for (const id of scoreIds) {
+      if (isNaN(parseInt(id)) || parseInt(id) < 1) {
+        throw new Error('Score IDs must be positive numbers')
+      }
+      ret.push(await this.fetchScore(id))
+    }
+    return ret
+  }
 }

--- a/src/controller/SheetsWrapper.js
+++ b/src/controller/SheetsWrapper.js
@@ -112,7 +112,7 @@ module.exports = class SheetsWrapper {
       spreadsheetId: SheetsWrapper.#SPREADSHEET_ID,
       range: `${mods}!A:G`,
       majorDimension: 'ROWS',
-      valueRenderOption: valueRenderOption
+      valueRenderOption
     })
     return response.data.values.slice(1)
   }
@@ -133,27 +133,6 @@ module.exports = class SheetsWrapper {
     })
     return response.data.values[0]
   }
-
-  // // Doesn't check if scores already in sheet
-  // async insertScores (mods, scores) {
-  //   console.info(`SheetsWrapper::insertScores( ${mods}, array of ${scores.length} scores )`)
-  //   if (Mods.toSheetId(mods) === -1) throw new Error(`${mods} is not a valid mod combination`)
-  //   for (const score of scores) {
-  //     if (!this.#isScore(score)) throw new Error(`Invalid score: [${score}]`)
-  //   }
-
-  //   const response = await this.#sheetsClient.spreadsheets.values.append({
-  //     auth: SheetsWrapper.#AUTH,
-  //     spreadsheetId: SheetsWrapper.#SPREADSHEET_ID,
-  //     range: `${mods}`,
-  //     valueInputOption: 'USER_ENTERED',
-  //     insertDataOption: 'INSERT_ROWS',
-  //     resource: {
-  //       values: scores
-  //     }
-  //   })
-  //   return response.data
-  // }
 
   async removeScore (mods, id) {
     console.info(`SheetsWrapper::removeScore( ${mods}, ${id} )`)
@@ -206,6 +185,41 @@ module.exports = class SheetsWrapper {
     })
     return response.data
   }
+
+  async fetchSubmittedScores () {
+    console.info('SheetsWrapper::fetchSubmittedScores()')
+    const response = await this.#sheetsClient.spreadsheets.values.get({
+      auth: SheetsWrapper.#AUTH,
+      spreadsheetId: SheetsWrapper.#SPREADSHEET_ID,
+      range: 'Submitted Scores!A:A',
+      majorDimension: 'COLUMNS'
+    })
+    return response.data.values[0].slice(1)
+  }
+
+  // Doesn't check if scores already in sheet
+  async submitScore (id) {
+    console.info(`SheetsWrapper::submitScore( ${id} )`)
+    if (isNaN(parseInt(id)) || parseInt(id) < 1) {
+      throw new Error('Score ID must be a positive number')
+    }
+
+    const response = await this.#sheetsClient.spreadsheets.values.append({
+      auth: SheetsWrapper.#AUTH,
+      spreadsheetId: SheetsWrapper.#SPREADSHEET_ID,
+      range: 'Submitted Scores',
+      valueInputOption: 'USER_ENTERED',
+      insertDataOption: 'INSERT_ROWS',
+      resource: {
+        values: [[id]]
+      }
+    })
+    return response.data
+  }
+
+  /* --- --- --- --- --- ---
+     --- PRIVATE METHODS ---
+     --- --- --- --- --- --- */
 
   // Returns true if score is typed properly, false otherwise
   // Doesn't check things like if ID exists, if hyperlink is proper, 0<acc<100, etc.


### PR DESCRIPTION
Making a PUT request for a score will add it to a buffer sheet, which the sheet update job uses. The benefit is that API calls are reduced in exchange for more prerendering (which is fine since it is a periodically ran asynchronous task; time is not an issue).

Presumably, this pull should complete the base functionality of the backend.